### PR TITLE
Eval reality usage

### DIFF
--- a/data/eval_dataset.json
+++ b/data/eval_dataset.json
@@ -11,7 +11,8 @@
         ],
         "axioms_used": [
             "A-001"
-        ]
+        ],
+        "reality_used": []
     },
     {
         "id": 2,
@@ -25,7 +26,8 @@
         ],
         "axioms_used": [
             "A-002"
-        ]
+        ],
+        "reality_used": []
     },
     {
         "id": 3,
@@ -39,7 +41,8 @@
         ],
         "axioms_used": [
             "A-003"
-        ]
+        ],
+        "reality_used": []
     },
     {
         "id": 4,
@@ -53,7 +56,8 @@
         ],
         "axioms_used": [
             "A-004"
-        ]
+        ],
+        "reality_used": []
     },
     {
         "id": 5,
@@ -67,7 +71,8 @@
         ],
         "axioms_used": [
             "A-007"
-        ]
+        ],
+        "reality_used": []
     },
     {
         "id": 6,

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -455,7 +455,7 @@ async def run_evaluation(
             an LLM-generated answer.
         input_data_path: Path to the input JSON file containing evaluation
             samples. Defaults to 'data/eval_dataset.json'.
-        ouptput_data_path: Path to the output directory for results.
+        output_data_path: Path to the output directory for results.
             Defaults to 'runs/{timestamp}'.
 
     Side Effects:

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -34,7 +34,8 @@ def calculate_mean_std(scores: list[float]) -> tuple[float, float]:
         scores: List of numeric scores to analyze.
 
     Returns:
-        Tuple of (mean, standard_deviation). Returns (0.0, 0.0) for empty lists.
+        Tuple of (mean, standard_deviation). 
+        Returns (0.0, 0.0) for empty lists.
         Standard deviation is 0.0 for single-element lists.
 
     Examples:

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -34,7 +34,7 @@ def calculate_mean_std(scores: list[float]) -> tuple[float, float]:
         scores: List of numeric scores to analyze.
 
     Returns:
-        Tuple of (mean, standard_deviation). 
+        Tuple of (mean, standard_deviation).
         Returns (0.0, 0.0) for empty lists.
         Standard deviation is 0.0 for single-element lists.
 
@@ -253,7 +253,6 @@ class QuestionAnswerFunction(Protocol):
     """
 
     # this is just the protocol
-
     async def __call__(self, *,
                        query: str) -> str:  # pyright: ignore[reportReturnType]
         """

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -166,6 +166,11 @@ async def evaluate_answer(
     def _calculate_precision_recall(found: list[str], expected: list[str]) -> tuple[float, float]:
         found_set = set(found)
         expected_set = set(expected)
+        
+        # If both are empty, the answer is correct (nothing expected, nothing found)
+        if not found_set and not expected_set:
+            return 1.0, 1.0
+        
         true_positives = len(found_set & expected_set)
         precision = true_positives / len(found_set) if found_set else 0.0
         recall = true_positives / len(expected_set) if expected_set else 0.0

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -225,9 +225,7 @@ class QuestionAnswerFunction(Protocol):
 
     # this is just the protocol
 
-    async def __call__(self,
-                       *,
-                       query: str) -> str:  # pyright: ignore[reportReturnType]
+    async def __call__(self, *, query: str) -> str:  # pyright: ignore[reportReturnType]
         """
         Takes a user query and returns a generated answer.
 

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -180,7 +180,8 @@ class QuestionAnswerFunction(Protocol):
 
     # this is just the protocol
 
-    async def __call__(self, *, query: str) -> str:  # pyright: ignore[reportReturnType]
+    # pyright: ignore[reportReturnType]
+    async def __call__(self, *, query: str) -> str:
         """
         Takes a user query and returns a generated answer.
 

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -252,9 +252,7 @@ class QuestionAnswerFunction(Protocol):
         >>> answer = await my_qa_function(query="What if it rains?")
     """
 
-    # this is just the protocol
-    async def __call__(self, *,
-                       query: str) -> str:  # pyright: ignore[reportReturnType]
+    async def __call__(self, *, query: str) -> str:
         """
         Takes a user query and returns a generated answer.
 
@@ -264,6 +262,7 @@ class QuestionAnswerFunction(Protocol):
         Returns:
             A generated answer as a string
         """
+        ...
 
 
 class EvaluationResult(BaseModel):

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -27,6 +27,34 @@ AXIOM_REFERENCE_PATTERN = r"\[A-\d+\]"
 REALITY_REFERENCE_PATTERN = r"\[R-\d+\]"
 
 
+def calculate_mean_std(scores: list[float]) -> tuple[float, float]:
+    """Calculate mean and standard deviation for a list of scores.
+
+    Args:
+        scores: List of numeric scores to analyze.
+
+    Returns:
+        Tuple of (mean, standard_deviation). Returns (0.0, 0.0) for empty lists.
+        Standard deviation is 0.0 for single-element lists.
+
+    Examples:
+        >>> calculate_mean_std([1.0, 2.0, 3.0])
+        (2.0, 0.816496580927726)
+        >>> calculate_mean_std([5.0])
+        (5.0, 0.0)
+        >>> calculate_mean_std([])
+        (0.0, 0.0)
+    """
+    if not scores:
+        return 0.0, 0.0
+
+    mean = sum(scores) / len(scores)
+    variance = sum((score - mean) ** 2 for score in scores) / len(scores)
+    std = variance**0.5 if len(scores) > 1 else 0.0
+
+    return mean, std
+
+
 def calculate_precision_recall(
     found: list[str], expected: list[str]
 ) -> tuple[float, float]:
@@ -225,7 +253,8 @@ class QuestionAnswerFunction(Protocol):
 
     # this is just the protocol
 
-    async def __call__(self, *, query: str) -> str:  # pyright: ignore[reportReturnType]
+    async def __call__(self, *,
+                       query: str) -> str:  # pyright: ignore[reportReturnType]
         """
         Takes a user query and returns a generated answer.
 
@@ -345,79 +374,44 @@ def calculate_stats(
     accuracy_scores = [
         result.accuracy.accuracy_mean for result in evaluation_results
     ]
-    accuracy_mean = sum(accuracy_scores) / len(accuracy_scores)
-    accuracy_variance = sum(
-        (score - accuracy_mean) ** 2 for score in accuracy_scores
-    ) / len(accuracy_scores)
-    accuracy_std = accuracy_variance**0.5 if len(accuracy_scores) > 1 else 0.0
+    accuracy_mean, accuracy_std = calculate_mean_std(accuracy_scores)
 
     # Calculate topic coverage statistics
     coverage_scores = [
         result.topic_coverage.coverage_score for result in evaluation_results
     ]
-    coverage_mean = sum(coverage_scores) / len(coverage_scores)
-    coverage_variance = sum(
-        (score - coverage_mean) ** 2 for score in coverage_scores
-    ) / len(coverage_scores)
-    coverage_std = coverage_variance**0.5 if len(coverage_scores) > 1 else 0.0
+    coverage_mean, coverage_std = calculate_mean_std(coverage_scores)
 
     # Calculate axiom precision statistics
     axiom_precision_scores = [
         result.axiom_references.precision for result in evaluation_results
     ]
-    axiom_precision_mean = sum(axiom_precision_scores) / len(
+    axiom_precision_mean, axiom_precision_std = calculate_mean_std(
         axiom_precision_scores
-    )
-    axiom_precision_variance = sum(
-        (score - axiom_precision_mean) ** 2 for score in axiom_precision_scores
-    ) / len(axiom_precision_scores)
-    axiom_precision_std = (
-        axiom_precision_variance**0.5
-        if len(axiom_precision_scores) > 1
-        else 0.0
     )
 
     # Calculate axiom recall statistics
     axiom_recall_scores = [
         result.axiom_references.recall for result in evaluation_results
     ]
-    axiom_recall_mean = sum(axiom_recall_scores) / len(axiom_recall_scores)
-    axiom_recall_variance = sum(
-        (score - axiom_recall_mean) ** 2 for score in axiom_recall_scores
-    ) / len(axiom_recall_scores)
-    axiom_recall_std = (
-        axiom_recall_variance**0.5 if len(axiom_recall_scores) > 1 else 0.0
+    axiom_recall_mean, axiom_recall_std = calculate_mean_std(
+        axiom_recall_scores
     )
 
     # Calculate reality precision statistics
     reality_precision_scores = [
         result.reality_references.precision for result in evaluation_results
     ]
-    reality_precision_mean = sum(reality_precision_scores) / len(
+    reality_precision_mean, reality_precision_std = calculate_mean_std(
         reality_precision_scores
-    )
-    reality_precision_variance = sum(
-        (score - reality_precision_mean) ** 2
-        for score in reality_precision_scores
-    ) / len(reality_precision_scores)
-    reality_precision_std = (
-        reality_precision_variance**0.5
-        if len(reality_precision_scores) > 1
-        else 0.0
     )
 
     # Calculate reality recall statistics
     reality_recall_scores = [
         result.reality_references.recall for result in evaluation_results
     ]
-    reality_recall_mean = sum(reality_recall_scores) / len(
+    reality_recall_mean, reality_recall_std = calculate_mean_std(
         reality_recall_scores
-    )
-    reality_recall_variance = sum(
-        (score - reality_recall_mean) ** 2 for score in reality_recall_scores
-    ) / len(reality_recall_scores)
-    reality_recall_std = (
-        reality_recall_variance**0.5 if len(reality_recall_scores) > 1 else 0.0
     )
 
     return EvaluationResult(

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -225,7 +225,9 @@ class QuestionAnswerFunction(Protocol):
 
     # this is just the protocol
 
-    async def __call__(self, *, query: str) -> str:  # pyright: ignore[reportReturnType]
+    async def __call__(self,
+                       *,
+                       query: str) -> str:  # pyright: ignore[reportReturnType]
         """
         Takes a user query and returns a generated answer.
 
@@ -443,7 +445,7 @@ async def run_evaluation(
     *,
     question_answer_fn: QuestionAnswerFunction,
     input_data_path: Path | None = None,
-    ouptput_data_path: Path | None = None,
+    output_data_path: Path | None = None,
 ) -> None:
     """Run the full evaluation pipeline.
 
@@ -467,7 +469,7 @@ async def run_evaluation(
 
     input_path = input_data_path or root() / "data/eval_dataset.json"
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_path = ouptput_data_path or root() / f"runs/{timestamp}"
+    output_path = output_data_path or root() / f"runs/{timestamp}"
     output_path.mkdir(parents=True, exist_ok=True)
 
     print(f"Running evaluation with data path: {input_path}")

--- a/src/eval/models.py
+++ b/src/eval/models.py
@@ -309,6 +309,18 @@ class EvaluationResult(BaseModel):
             predictions or responses across the evaluation dataset.
         topic_coverage (CoverageMetric): Metric measuring how well the
             evaluation spans different topics or categories in the domain.
+        axiom_precision_metric (AxiomPrecisionMetric): Metric measuring
+            the precision of axiom references (ratio of correct axiom
+            references to total axiom references found).
+        axiom_recall_metric (AxiomRecallMetric): Metric measuring the
+            recall of axiom references (ratio of found axiom references
+            to expected axiom references).
+        reality_precision_metric (RealityPrecisionMetric): Metric measuring
+            the precision of reality references (ratio of correct reality
+            references to total reality references found).
+        reality_recall_metric (RealityRecallMetric): Metric measuring the
+            recall of reality references (ratio of found reality references
+            to expected reality references).
     """
 
     evaluation_outputs: list[EvaluationSampleOutput]

--- a/src/eval/models.py
+++ b/src/eval/models.py
@@ -1,5 +1,8 @@
 from pydantic import BaseModel, Field
 
+AxiomReferences = list[str]
+RealityReferences = list[str]
+
 
 class Entity(BaseModel):
     """
@@ -121,6 +124,36 @@ class TopicCoverageEvaluationResults(BaseModel):
     )
 
 
+class AxiomReferenceResults(BaseModel):
+    """
+    A model for storing axiom reference evaluation results.
+    """
+
+    references_found: AxiomReferences = Field(
+        description="List of axiom references found in the LLM answer."
+    )
+    references_expected: AxiomReferences = Field(
+        description="List of axiom references expected in the answer."
+    )
+    precision: float = Field(
+        description="Precision score for axiom references, between 0.0 and 1.0.",
+        ge=0.0,
+        le=1.0,
+    )
+    recall: float = Field(
+        description="Recall score for axiom references, between 0.0 and 1.0.",
+        ge=0.0,
+        le=1.0,
+    )
+
+
+class RealityReferenceResults(AxiomReferenceResults):
+    """
+    A model for storing reality reference evaluation results.
+    """
+    pass
+
+
 class Metric(BaseModel):
     """
     A data model representing statistical metrics with mean and standard
@@ -173,6 +206,18 @@ class CoverageMetric(Metric):
     """
 
 
+class AxiomReferenceMetric(Metric):
+    """
+    A metric class for measuring axiom reference accuracy during evaluation.
+    """
+
+
+class RealityReferenceMetric(Metric):
+    """
+    A metric class for measuring reality reference accuracy during evaluation.
+    """
+
+
 class EvaluationSampleInput(BaseModel):
     """
     A data model representing input data for evaluation samples.
@@ -192,6 +237,8 @@ class EvaluationSampleInput(BaseModel):
             that lead to the expected answer.
         axioms_used (list[str]): List of axioms, rules, or principles
             applied in deriving the expected answer.
+        reality_used (list[str]): List of real-world facts or data
+            referenced in formulating the expected answer.
     """
 
     id: int
@@ -199,7 +246,8 @@ class EvaluationSampleInput(BaseModel):
     context: str
     expected_answer: str
     reasoning: list[str]
-    axioms_used: list[str]
+    axioms_used: AxiomReferences
+    reality_used: RealityReferences
 
 
 class EvaluationSampleOutput(BaseModel):
@@ -228,6 +276,8 @@ class EvaluationSampleOutput(BaseModel):
     entities: EntityExtraction
     accuracy: AccuracyEvaluationResults
     topic_coverage: TopicCoverageEvaluationResults
+    axiom_references: AxiomReferenceResults
+    reality_references: RealityReferenceResults
 
 
 class EvaluationResult(BaseModel):
@@ -251,3 +301,5 @@ class EvaluationResult(BaseModel):
     evaluation_outputs: list[EvaluationSampleOutput]
     accuracy: AccuracyMetric
     topic_coverage: CoverageMetric
+    axiom_metric: AxiomReferenceMetric
+    reality_metric: RealityReferenceMetric

--- a/src/eval/models.py
+++ b/src/eval/models.py
@@ -124,30 +124,42 @@ class TopicCoverageEvaluationResults(BaseModel):
     )
 
 
-class AxiomReferenceResults(BaseModel):
+class ReferenceResults(BaseModel):
     """
-    A model for storing axiom reference evaluation results.
+    Base model for storing reference evaluation results.
+
+    This class provides the common structure for evaluating references
+    (axioms or reality facts) cited in LLM responses against expected
+    references.
     """
 
-    references_found: AxiomReferences = Field(
-        description="List of axiom references found in the LLM answer."
+    references_found: list[str] = Field(
+        description="List of references found in the LLM answer."
     )
-    references_expected: AxiomReferences = Field(
-        description="List of axiom references expected in the answer."
+    references_expected: list[str] = Field(
+        description="List of references expected in the answer."
     )
     precision: float = Field(
-        description="Precision score for axiom references (0.0 to 1.0).",
+        description="Precision score for references (0.0 to 1.0).",
         ge=0.0,
         le=1.0,
     )
     recall: float = Field(
-        description="Recall score for axiom references, between 0.0 and 1.0.",
+        description="Recall score for references, between 0.0 and 1.0.",
         ge=0.0,
         le=1.0,
     )
 
 
-class RealityReferenceResults(AxiomReferenceResults):
+class AxiomReferenceResults(ReferenceResults):
+    """
+    A model for storing axiom reference evaluation results.
+    """
+
+    pass
+
+
+class RealityReferenceResults(ReferenceResults):
     """
     A model for storing reality reference evaluation results.
     """

--- a/src/eval/models.py
+++ b/src/eval/models.py
@@ -206,15 +206,27 @@ class CoverageMetric(Metric):
     """
 
 
-class AxiomReferenceMetric(Metric):
+class AxiomPrecisionMetric(Metric):
     """
-    A metric class for measuring axiom reference accuracy during evaluation.
+    A metric class for measuring axiom reference precision during evaluation.
     """
 
 
-class RealityReferenceMetric(Metric):
+class AxiomRecallMetric(Metric):
     """
-    A metric class for measuring reality reference accuracy during evaluation.
+    A metric class for measuring axiom reference recall during evaluation.
+    """
+
+
+class RealityPrecisionMetric(Metric):
+    """
+    A metric class for measuring reality reference precision during evaluation.
+    """
+
+
+class RealityRecallMetric(Metric):
+    """
+    A metric class for measuring reality reference recall during evaluation.
     """
 
 
@@ -301,5 +313,7 @@ class EvaluationResult(BaseModel):
     evaluation_outputs: list[EvaluationSampleOutput]
     accuracy: AccuracyMetric
     topic_coverage: CoverageMetric
-    axiom_metric: AxiomReferenceMetric
-    reality_metric: RealityReferenceMetric
+    axiom_precision_metric: AxiomPrecisionMetric
+    axiom_recall_metric: AxiomRecallMetric
+    reality_precision_metric: RealityPrecisionMetric
+    reality_recall_metric: RealityRecallMetric

--- a/src/eval/models.py
+++ b/src/eval/models.py
@@ -136,7 +136,7 @@ class AxiomReferenceResults(BaseModel):
         description="List of axiom references expected in the answer."
     )
     precision: float = Field(
-        description="Precision score for axiom references, between 0.0 and 1.0.",
+        description="Precision score for axiom references (0.0 to 1.0).",
         ge=0.0,
         le=1.0,
     )
@@ -151,6 +151,7 @@ class RealityReferenceResults(AxiomReferenceResults):
     """
     A model for storing reality reference evaluation results.
     """
+
     pass
 
 

--- a/src/eval/report_generation/templates/index.html
+++ b/src/eval/report_generation/templates/index.html
@@ -34,6 +34,14 @@
                     <p>Average Topic Coverage</p>
                 </div>
                 <div class="summary-card">
+                    <h3 id="avg-axiom-recall">0.00</h3>
+                    <p>Axiom Recall</p>
+                </div>
+                <div class="summary-card">
+                    <h3 id="avg-reality-recall">0.00</h3>
+                    <p>Reality Recall</p>
+                </div>
+                <div class="summary-card">
                     <h3 id="overall-score">0.00</h3>
                     <p>Overall Performance</p>
                 </div>

--- a/src/eval/report_generation/templates/index.html
+++ b/src/eval/report_generation/templates/index.html
@@ -34,8 +34,16 @@
                     <p>Average Topic Coverage</p>
                 </div>
                 <div class="summary-card">
+                    <h3 id="avg-axiom-precision">0.00</h3>
+                    <p>Axiom Precision</p>
+                </div>
+                <div class="summary-card">
                     <h3 id="avg-axiom-recall">0.00</h3>
                     <p>Axiom Recall</p>
+                </div>
+                <div class="summary-card">
+                    <h3 id="avg-reality-precision">0.00</h3>
+                    <p>Reality Precision</p>
                 </div>
                 <div class="summary-card">
                     <h3 id="avg-reality-recall">0.00</h3>

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -466,8 +466,12 @@ function calculateSummaryStats() {
     const avgCoverage = evaluations.reduce((sum, evaluation) => sum + evaluation.topic_coverage.coverage_score, 0) / totalEvaluations;
 
     // Calculate axiom and reality recall averages
+    const avgAxiomPrecision = evaluations.reduce((sum, evaluation) =>
+        sum + (evaluation.axiom_references?.precision || 0), 0) / totalEvaluations;
     const avgAxiomRecall = evaluations.reduce((sum, evaluation) =>
         sum + (evaluation.axiom_references?.recall || 0), 0) / totalEvaluations;
+    const avgRealityPrecision = evaluations.reduce((sum, evaluation) =>
+        sum + (evaluation.reality_references?.precision || 0), 0) / totalEvaluations;
     const avgRealityRecall = evaluations.reduce((sum, evaluation) =>
         sum + (evaluation.reality_references?.recall || 0), 0) / totalEvaluations;
 
@@ -483,8 +487,14 @@ function calculateSummaryStats() {
     const coverageEl = document.getElementById('avg-coverage');
     if (coverageEl) coverageEl.textContent = avgCoverage.toFixed(2);
 
+    const axiomPrecisionEl = document.getElementById('avg-axiom-precision');
+    if (axiomPrecisionEl) axiomPrecisionEl.textContent = avgAxiomPrecision.toFixed(2);
+
     const axiomRecallEl = document.getElementById('avg-axiom-recall');
     if (axiomRecallEl) axiomRecallEl.textContent = avgAxiomRecall.toFixed(2);
+
+    const realityPrecisionEl = document.getElementById('avg-reality-precision');
+    if (realityPrecisionEl) realityPrecisionEl.textContent = avgRealityPrecision.toFixed(2);
 
     const realityRecallEl = document.getElementById('avg-reality-recall');
     if (realityRecallEl) realityRecallEl.textContent = avgRealityRecall.toFixed(2);

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -117,6 +117,19 @@ function getScoreClass(score) {
 }
 
 /**
+ * Creates an HTML score badge with appropriate color styling.
+ * @param {string} label - The label to display (e.g., "Accuracy", "Coverage")
+ * @param {number} score - The score value between 0 and 1
+ * @param {string} [extraClass] - Optional additional CSS class (e.g., "score-accuracy")
+ * @returns {string} HTML string for the score badge
+ */
+function createScoreBadge(label, score, extraClass = '') {
+    const scoreClass = getScoreClass(score);
+    const classes = extraClass ? `score-badge ${extraClass} ${scoreClass}` : `score-badge ${scoreClass}`;
+    return `<div class="${classes}">${label}: ${(score * 100).toFixed(0)}%</div>`;
+}
+
+/**
  * Converts line break characters to HTML <br> tags and markdown bold to HTML <b> tags.
  * Handles various line break formats (CRLF, LF, CR) for cross-platform compatibility.
  * @param {string} text - The text to convert
@@ -366,12 +379,10 @@ function renderAccuracyDetails(accuracy) {
  * @returns {string} HTML string containing the full evaluation display
  */
 function renderEvaluation(evaluation) {
-    const accuracyClass = getScoreClass(evaluation.accuracy.accuracy_mean);
-    const coverageClass = getScoreClass(
-        evaluation.topic_coverage.coverage_score
-    );
-    const axiomPrecisionClass = getScoreClass(evaluation.axiom_references?.precision || 0);
-    const realityPrecisionClass = getScoreClass(evaluation.reality_references?.precision || 0);
+    const accuracyScore = evaluation.accuracy.accuracy_mean;
+    const coverageScore = evaluation.topic_coverage.coverage_score;
+    const axiomPrecisionScore = evaluation.axiom_references?.precision ?? 0;
+    const realityPrecisionScore = evaluation.reality_references?.precision ?? 0;
 
     // Collect all entities for analysis
     const allEntityValues = [];
@@ -425,18 +436,10 @@ function renderEvaluation(evaluation) {
             <div class="evaluation-header collapsed" role="button" tabindex="0" aria-expanded="false" onclick="toggleEvaluation(this)">
                 <div class="evaluation-id">Evaluation #${evaluation.input.id}</div>
                 <div class="scores">
-                    <div class="score-badge score-accuracy ${accuracyClass}">
-                        Accuracy: ${(evaluation.accuracy.accuracy_mean * 100).toFixed(0)}%
-                    </div>
-                    <div class="score-badge score-coverage ${coverageClass}">
-                        Coverage: ${(evaluation.topic_coverage.coverage_score * 100).toFixed(0)}%
-                    </div>
-                    <div class="score-badge ${axiomPrecisionClass}">
-                        Axiom: ${((evaluation.axiom_references?.precision || 0) * 100).toFixed(0)}%
-                    </div>
-                    <div class="score-badge ${realityPrecisionClass}">
-                        Reality: ${((evaluation.reality_references?.precision || 0) * 100).toFixed(0)}%
-                    </div>
+                    ${createScoreBadge('Accuracy', accuracyScore, 'score-accuracy')}
+                    ${createScoreBadge('Coverage', coverageScore, 'score-coverage')}
+                    ${createScoreBadge('Axiom', axiomPrecisionScore)}
+                    ${createScoreBadge('Reality', realityPrecisionScore)}
                 </div>
             </div>
             <div class="evaluation-content collapsed">
@@ -483,8 +486,8 @@ function renderEvaluation(evaluation) {
                 <div class="score-item">
                     <div class="score-header">
                         <h5>Accuracy (Mean)</h5>
-                        <span class="score-badge ${accuracyClass}">
-                            ${(evaluation.accuracy.accuracy_mean * 100).toFixed(0)}%
+                        <span class="score-badge ${getScoreClass(accuracyScore)}">
+                            ${(accuracyScore * 100).toFixed(0)}%
                         </span>
                     </div>
                     ${renderAccuracyDetails(evaluation.accuracy)}
@@ -492,8 +495,8 @@ function renderEvaluation(evaluation) {
                 <div class="score-item">
                     <div class="score-header">
                         <h5>Topic Coverage</h5>
-                        <span class="score-badge ${coverageClass}">
-                            ${(evaluation.topic_coverage.coverage_score * 100).toFixed(0)}%
+                        <span class="score-badge ${getScoreClass(coverageScore)}">
+                            ${(coverageScore * 100).toFixed(0)}%
                         </span>
                     </div>
                     <div class="score-reason">${convertLineBreaks(evaluation.topic_coverage.reason)}</div>

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -454,26 +454,20 @@ function initializeEntityColors() {
 }
 
 /**
- * Calculates and displays summary statistics for all evaluations.
- * Computes average accuracy, coverage, and overall scores, then updates DOM elements.
+ * Displays summary statistics from pre-calculated metrics in the evaluation data.
  * Updates the summary statistics section at the top of the report.
  */
 function calculateSummaryStats() {
-    const evaluations = window.evaluationData.evaluation_outputs;
-    const totalEvaluations = evaluations.length;
+    const data = window.evaluationData;
+    const totalEvaluations = data.evaluation_outputs.length;
 
-    const avgAccuracy = evaluations.reduce((sum, evaluation) => sum + evaluation.accuracy.accuracy_mean, 0) / totalEvaluations;
-    const avgCoverage = evaluations.reduce((sum, evaluation) => sum + evaluation.topic_coverage.coverage_score, 0) / totalEvaluations;
-
-    // Calculate axiom and reality recall averages
-    const avgAxiomPrecision = evaluations.reduce((sum, evaluation) =>
-        sum + (evaluation.axiom_references?.precision || 0), 0) / totalEvaluations;
-    const avgAxiomRecall = evaluations.reduce((sum, evaluation) =>
-        sum + (evaluation.axiom_references?.recall || 0), 0) / totalEvaluations;
-    const avgRealityPrecision = evaluations.reduce((sum, evaluation) =>
-        sum + (evaluation.reality_references?.precision || 0), 0) / totalEvaluations;
-    const avgRealityRecall = evaluations.reduce((sum, evaluation) =>
-        sum + (evaluation.reality_references?.recall || 0), 0) / totalEvaluations;
+    // Use pre-calculated metrics from the JSON
+    const avgAccuracy = data.accuracy?.mean || 0;
+    const avgCoverage = data.topic_coverage?.mean || 0;
+    const avgAxiomPrecision = data.axiom_precision_metric?.mean || 0;
+    const avgAxiomRecall = data.axiom_recall_metric?.mean || 0;
+    const avgRealityPrecision = data.reality_precision_metric?.mean || 0;
+    const avgRealityRecall = data.reality_recall_metric?.mean || 0;
 
     const overallScore = (avgAccuracy + avgCoverage + avgAxiomRecall + avgRealityRecall) / 4;
 

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -382,7 +382,9 @@ function renderEvaluation(evaluation) {
     const accuracyScore = evaluation.accuracy.accuracy_mean;
     const coverageScore = evaluation.topic_coverage.coverage_score;
     const axiomPrecisionScore = evaluation.axiom_references?.precision ?? 0;
+    const axiomRecallScore = evaluation.axiom_references?.recall ?? 0;
     const realityPrecisionScore = evaluation.reality_references?.precision ?? 0;
+    const realityRecallScore = evaluation.reality_references?.recall ?? 0;
 
     // Collect all entities for analysis
     const allEntityValues = [];
@@ -438,8 +440,10 @@ function renderEvaluation(evaluation) {
                 <div class="scores">
                     ${createScoreBadge('Accuracy', accuracyScore, 'score-accuracy')}
                     ${createScoreBadge('Coverage', coverageScore, 'score-coverage')}
-                    ${createScoreBadge('Axiom', axiomPrecisionScore)}
-                    ${createScoreBadge('Reality', realityPrecisionScore)}
+                    ${createScoreBadge('Axiom P', axiomPrecisionScore)}
+                    ${createScoreBadge('Axiom R', axiomRecallScore)}
+                    ${createScoreBadge('Reality P', realityPrecisionScore)}
+                    ${createScoreBadge('Reality R', realityRecallScore)}
                 </div>
             </div>
             <div class="evaluation-content collapsed">
@@ -559,6 +563,13 @@ function calculateSummaryStats() {
     const avgRealityPrecision = data.reality_precision_metric?.mean ?? 0;
     const avgRealityRecall = data.reality_recall_metric?.mean ?? 0;
 
+    // Overall score is the unweighted average of all 6 evaluation metrics:
+    // - Accuracy: How well the LLM response matches the expected answer
+    // - Coverage: How well the response covers the expected topics
+    // - Axiom Precision: Proportion of cited axioms that are relevant
+    // - Axiom Recall: Proportion of relevant axioms that were cited
+    // - Reality Precision: Proportion of cited reality facts that are relevant
+    // - Reality Recall: Proportion of relevant reality facts that were cited
     const overallScore = (
         avgAccuracy +
         avgCoverage +

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -559,7 +559,14 @@ function calculateSummaryStats() {
     const avgRealityPrecision = data.reality_precision_metric?.mean ?? 0;
     const avgRealityRecall = data.reality_recall_metric?.mean ?? 0;
 
-    const overallScore = (avgAccuracy + avgCoverage + avgAxiomRecall + avgRealityRecall) / 4;
+    const overallScore = (
+        avgAccuracy +
+        avgCoverage +
+        avgAxiomPrecision +
+        avgAxiomRecall +
+        avgRealityPrecision +
+        avgRealityRecall
+    ) / 6;
 
     // Safely update summary statistics elements
     const totalEl = document.getElementById('total-evaluations');

--- a/src/eval/report_generation/templates/styles.css
+++ b/src/eval/report_generation/templates/styles.css
@@ -129,7 +129,7 @@ body {
 
 .scores {
     display: flex;
-    gap: 15px;
+    gap: 10px;
     flex-wrap: wrap;
 }
 
@@ -139,7 +139,8 @@ body {
     font-weight: bold;
     font-size: 0.9rem;
     text-align: center;
-    min-width: 80px;
+    width: 140px;
+    flex: 0 0 140px;
 }
 
 .score-accuracy {
@@ -154,14 +155,17 @@ body {
 
 .score-good {
     background: #51cf66;
+    color: white;
 }
 
 .score-medium {
     background: #ffd43b;
+    color: white;
 }
 
 .score-poor {
     background: #ff6b6b;
+    color: white;
 }
 
 .query {
@@ -294,6 +298,84 @@ body {
     font-weight: bold;
 }
 
+/* References section (Axiom and Reality references comparison) */
+.references-section {
+    margin: 20px 0;
+    background: #f0f4f8;
+    padding: 15px;
+    border-radius: 8px;
+    border-left: 4px solid #5c6bc0;
+}
+
+.references-section h4 {
+    color: #5c6bc0;
+    margin-bottom: 12px;
+    font-size: 1rem;
+}
+
+.references-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+    margin-bottom: 12px;
+}
+
+@media (max-width: 600px) {
+    .references-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.references-card {
+    background: white;
+    padding: 12px;
+    border-radius: 6px;
+    border: 1px solid #e0e0e0;
+}
+
+.references-card h5 {
+    color: #495057;
+    margin-bottom: 8px;
+    font-size: 0.85rem;
+}
+
+.reference-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.reference-tag {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+.expected-tag {
+    background: #e3f2fd;
+    color: #1565c0;
+    border: 1px solid #90caf9;
+}
+
+.found-match-tag {
+    background: #c8e6c9;
+    color: #2e7d32;
+    border: 1px solid #81c784;
+}
+
+.found-nomatch-tag {
+    background: #ffcdd2;
+    color: #c62828;
+    border: 1px solid #ef9a9a;
+}
+
+.references-metrics {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
 .entities {
     margin: 20px 0;
 }
@@ -344,26 +426,97 @@ body {
 }
 
 /* Entity color classes - consistent colors for same entities across sections */
-.entity-color-0 { background-color: #667eea; }
-.entity-color-1 { background-color: #f093fb; }
-.entity-color-2 { background-color: #4ecdc4; }
-.entity-color-3 { background-color: #45b7d1; }
-.entity-color-4 { background-color: #96ceb4; }
-.entity-color-5 { background-color: #ffecd2; color: #333; }
-.entity-color-6 { background-color: #a8edea; color: #333; }
-.entity-color-7 { background-color: #d299c2; }
-.entity-color-8 { background-color: #fad0c4; color: #333; }
-.entity-color-9 { background-color: #a18cd1; }
-.entity-color-10 { background-color: #fbc2eb; color: #333; }
-.entity-color-11 { background-color: #84fab0; color: #333; }
-.entity-color-12 { background-color: #f6d365; color: #333; }
-.entity-color-13 { background-color: #fa709a; }
-.entity-color-14 { background-color: #fee140; color: #333; }
-.entity-color-15 { background-color: #f7b267; color: #333; }
-.entity-color-16 { background-color: #d0bfff; color: #333; }
-.entity-color-17 { background-color: #b8f2ff; color: #333; }
-.entity-color-18 { background-color: #ffd93d; color: #333; }
-.entity-color-19 { background-color: #74c0fc; color: #333; }
+.entity-color-0 {
+    background-color: #667eea;
+}
+
+.entity-color-1 {
+    background-color: #f093fb;
+}
+
+.entity-color-2 {
+    background-color: #4ecdc4;
+}
+
+.entity-color-3 {
+    background-color: #45b7d1;
+}
+
+.entity-color-4 {
+    background-color: #96ceb4;
+}
+
+.entity-color-5 {
+    background-color: #ffecd2;
+    color: #333;
+}
+
+.entity-color-6 {
+    background-color: #a8edea;
+    color: #333;
+}
+
+.entity-color-7 {
+    background-color: #d299c2;
+}
+
+.entity-color-8 {
+    background-color: #fad0c4;
+    color: #333;
+}
+
+.entity-color-9 {
+    background-color: #a18cd1;
+}
+
+.entity-color-10 {
+    background-color: #fbc2eb;
+    color: #333;
+}
+
+.entity-color-11 {
+    background-color: #84fab0;
+    color: #333;
+}
+
+.entity-color-12 {
+    background-color: #f6d365;
+    color: #333;
+}
+
+.entity-color-13 {
+    background-color: #fa709a;
+}
+
+.entity-color-14 {
+    background-color: #fee140;
+    color: #333;
+}
+
+.entity-color-15 {
+    background-color: #f7b267;
+    color: #333;
+}
+
+.entity-color-16 {
+    background-color: #d0bfff;
+    color: #333;
+}
+
+.entity-color-17 {
+    background-color: #b8f2ff;
+    color: #333;
+}
+
+.entity-color-18 {
+    background-color: #ffd93d;
+    color: #333;
+}
+
+.entity-color-19 {
+    background-color: #74c0fc;
+    color: #333;
+}
 
 /* Entity highlighting in text - same colors but with transparency */
 .entity-highlight {
@@ -372,49 +525,84 @@ body {
     font-weight: 500;
 }
 
-.entity-highlight.entity-color-0 { background-color: rgba(102, 126, 234, 0.3); }
-.entity-highlight.entity-color-1 { background-color: rgba(240, 147, 251, 0.3); }
-.entity-highlight.entity-color-2 { background-color: rgba(78, 205, 196, 0.3); }
-.entity-highlight.entity-color-3 { background-color: rgba(69, 183, 209, 0.3); }
-.entity-highlight.entity-color-4 { background-color: rgba(150, 206, 180, 0.3); }
-.entity-highlight.entity-color-5 { 
-    background-color: rgba(255, 236, 210, 0.5); 
+.entity-highlight.entity-color-0 {
+    background-color: rgba(102, 126, 234, 0.3);
 }
-.entity-highlight.entity-color-6 { 
-    background-color: rgba(168, 237, 234, 0.5); 
+
+.entity-highlight.entity-color-1 {
+    background-color: rgba(240, 147, 251, 0.3);
 }
-.entity-highlight.entity-color-7 { background-color: rgba(210, 153, 194, 0.3); }
-.entity-highlight.entity-color-8 { 
-    background-color: rgba(250, 208, 196, 0.5); 
+
+.entity-highlight.entity-color-2 {
+    background-color: rgba(78, 205, 196, 0.3);
 }
-.entity-highlight.entity-color-9 { background-color: rgba(161, 140, 209, 0.3); }
-.entity-highlight.entity-color-10 { 
-    background-color: rgba(251, 194, 235, 0.5); 
+
+.entity-highlight.entity-color-3 {
+    background-color: rgba(69, 183, 209, 0.3);
 }
-.entity-highlight.entity-color-11 { 
-    background-color: rgba(132, 250, 176, 0.5); 
+
+.entity-highlight.entity-color-4 {
+    background-color: rgba(150, 206, 180, 0.3);
 }
-.entity-highlight.entity-color-12 { 
-    background-color: rgba(246, 211, 101, 0.5); 
+
+.entity-highlight.entity-color-5 {
+    background-color: rgba(255, 236, 210, 0.5);
 }
-.entity-highlight.entity-color-13 { background-color: rgba(250, 112, 154, 0.3); }
-.entity-highlight.entity-color-14 { 
-    background-color: rgba(254, 225, 64, 0.5); 
+
+.entity-highlight.entity-color-6 {
+    background-color: rgba(168, 237, 234, 0.5);
 }
-.entity-highlight.entity-color-15 { 
-    background-color: rgba(255, 183, 197, 0.5); 
+
+.entity-highlight.entity-color-7 {
+    background-color: rgba(210, 153, 194, 0.3);
 }
-.entity-highlight.entity-color-16 { 
-    background-color: rgba(208, 191, 255, 0.5); 
+
+.entity-highlight.entity-color-8 {
+    background-color: rgba(250, 208, 196, 0.5);
 }
-.entity-highlight.entity-color-17 { 
-    background-color: rgba(184, 242, 255, 0.5); 
+
+.entity-highlight.entity-color-9 {
+    background-color: rgba(161, 140, 209, 0.3);
 }
-.entity-highlight.entity-color-18 { 
-    background-color: rgba(255, 217, 61, 0.5); 
+
+.entity-highlight.entity-color-10 {
+    background-color: rgba(251, 194, 235, 0.5);
 }
-.entity-highlight.entity-color-19 { 
-    background-color: rgba(116, 192, 252, 0.5); 
+
+.entity-highlight.entity-color-11 {
+    background-color: rgba(132, 250, 176, 0.5);
+}
+
+.entity-highlight.entity-color-12 {
+    background-color: rgba(246, 211, 101, 0.5);
+}
+
+.entity-highlight.entity-color-13 {
+    background-color: rgba(250, 112, 154, 0.3);
+}
+
+.entity-highlight.entity-color-14 {
+    background-color: rgba(254, 225, 64, 0.5);
+}
+
+.entity-highlight.entity-color-15 {
+    background-color: rgba(255, 183, 197, 0.5);
+}
+
+.entity-highlight.entity-color-16 {
+    background-color: rgba(208, 191, 255, 0.5);
+}
+
+.entity-highlight.entity-color-17 {
+    background-color: rgba(184, 242, 255, 0.5);
+}
+
+.entity-highlight.entity-color-18 {
+    background-color: rgba(255, 217, 61, 0.5);
+}
+
+.entity-highlight.entity-color-19 {
+    background-color: rgba(116, 192, 252, 0.5);
 }
 
 .evaluation-scores {

--- a/src/eval/report_generation/templates/styles.css
+++ b/src/eval/report_generation/templates/styles.css
@@ -160,7 +160,7 @@ body {
 
 .score-medium {
     background: #ffd43b;
-    color: white;
+    color: #333;
 }
 
 .score-poor {

--- a/tests/eval/test_reference_evaluation.py
+++ b/tests/eval/test_reference_evaluation.py
@@ -19,6 +19,8 @@ from eval.eval import (
     calculate_precision_recall,
     evaluate_axiom_references,
     evaluate_reality_references,
+    AXIOM_REFERENCE_PATTERN as AXIOM_PATTERN,
+    REALITY_REFERENCE_PATTERN as REALITY_PATTERN,
 )
 from eval.models import (
     AxiomPrecisionMetric,
@@ -43,11 +45,6 @@ SAMPLE_AXIOMS_FOUND: AxiomReferences = ["A-001", "A-002", "A-004"]
 SAMPLE_REALITY_EXPECTED: RealityReferences = ["R-001", "R-002"]
 SAMPLE_REALITY_FOUND: RealityReferences = ["R-001", "R-003"]
 
-# Regex patterns for reference extraction
-AXIOM_PATTERN = r"\[A-\d+\]"
-REALITY_PATTERN = r"\[R-\d+\]"
-
-
 # =============================================================================
 # Tests for Precision/Recall Calculation
 # =============================================================================
@@ -64,17 +61,17 @@ REALITY_PATTERN = r"\[R-\d+\]"
         ([], ["A-001", "A-002"], 0.0, 0.0),
         # Found not empty, expected empty
         (["A-001"], [], 0.0, 0.0),
-        # Partial overlap (2/3 each)
+        # Partial overlap (2/3 each, rounded to 4 decimals)
         (
             ["A-001", "A-002", "A-004"],
             ["A-001", "A-002", "A-003"],
-            2 / 3,
-            2 / 3,
+            0.6667,
+            0.6667,
         ),
         # No overlap
         (["A-001", "A-002"], ["A-003", "A-004"], 0.0, 0.0),
-        # All found correct but missing some (precision=1, recall=1/3)
-        (["A-001"], ["A-001", "A-002", "A-003"], 1.0, 1 / 3),
+        # All found correct but missing some (precision=1, recall=1/3 rounded)
+        (["A-001"], ["A-001", "A-002", "A-003"], 1.0, 0.3333),
         # Found more than expected (precision=0.5, recall=1)
         (["A-001", "A-002", "A-003", "A-004"], ["A-001", "A-002"], 0.5, 1.0),
         # Duplicates in found (set removes them)
@@ -429,8 +426,8 @@ def test_statistics_calculation(
             AXIOM_PATTERN,
             evaluate_axiom_references,
             ["[A-001]", "[A-002]", "[A-003]"],
-            2 / 3,
-            2 / 3,
+            0.6667,
+            0.6667,
         ),
         # Reality evaluation workflow
         (
@@ -443,7 +440,7 @@ def test_statistics_calculation(
             evaluate_reality_references,
             ["[R-001]", "[R-002]"],
             1.0,
-            2 / 3,
+            0.6667,
         ),
     ],
     ids=["axiom_workflow", "reality_workflow"],

--- a/tests/eval/test_reference_evaluation.py
+++ b/tests/eval/test_reference_evaluation.py
@@ -16,11 +16,15 @@ import pytest
 from pytest import approx  # type: ignore[reportUnknownMemberType]
 
 from eval.eval import (
+    AXIOM_REFERENCE_PATTERN as AXIOM_PATTERN,
+)
+from eval.eval import (
+    REALITY_REFERENCE_PATTERN as REALITY_PATTERN,
+)
+from eval.eval import (
     calculate_precision_recall,
     evaluate_axiom_references,
     evaluate_reality_references,
-    AXIOM_REFERENCE_PATTERN as AXIOM_PATTERN,
-    REALITY_REFERENCE_PATTERN as REALITY_PATTERN,
 )
 from eval.models import (
     AxiomPrecisionMetric,

--- a/tests/eval/test_reference_evaluation.py
+++ b/tests/eval/test_reference_evaluation.py
@@ -1,0 +1,490 @@
+"""
+Tests for axiom and reality reference evaluation functionality.
+
+This module tests:
+- Precision and recall calculation for references
+- Axiom reference extraction from LLM answers
+- Reality reference extraction from LLM answers
+- Reference evaluation results models
+- Statistics calculation for reference metrics
+"""
+
+import re
+from typing import Any
+
+import pytest
+from pytest import approx  # type: ignore[reportUnknownMemberType]
+
+from eval.eval import (
+    calculate_precision_recall,
+    evaluate_axiom_references,
+    evaluate_reality_references,
+)
+from eval.models import (
+    AxiomPrecisionMetric,
+    AxiomRecallMetric,
+    AxiomReferenceResults,
+    AxiomReferences,
+    RealityPrecisionMetric,
+    RealityRecallMetric,
+    RealityReferenceResults,
+    RealityReferences,
+)
+
+# =============================================================================
+# Test Data
+# =============================================================================
+
+# Sample axiom references for testing
+SAMPLE_AXIOMS_EXPECTED: AxiomReferences = ["A-001", "A-002", "A-003"]
+SAMPLE_AXIOMS_FOUND: AxiomReferences = ["A-001", "A-002", "A-004"]
+
+# Sample reality references for testing
+SAMPLE_REALITY_EXPECTED: RealityReferences = ["R-001", "R-002"]
+SAMPLE_REALITY_FOUND: RealityReferences = ["R-001", "R-003"]
+
+# Regex patterns for reference extraction
+AXIOM_PATTERN = r"\[A-\d+\]"
+REALITY_PATTERN = r"\[R-\d+\]"
+
+
+# =============================================================================
+# Tests for Precision/Recall Calculation
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("found", "expected", "expected_precision", "expected_recall"),
+    [
+        # Perfect match
+        (["A-001", "A-002"], ["A-001", "A-002"], 1.0, 1.0),
+        # Both empty
+        ([], [], 1.0, 1.0),
+        # Found empty, expected not empty
+        ([], ["A-001", "A-002"], 0.0, 0.0),
+        # Found not empty, expected empty
+        (["A-001"], [], 0.0, 0.0),
+        # Partial overlap (2/3 each)
+        (
+            ["A-001", "A-002", "A-004"],
+            ["A-001", "A-002", "A-003"],
+            2 / 3,
+            2 / 3,
+        ),
+        # No overlap
+        (["A-001", "A-002"], ["A-003", "A-004"], 0.0, 0.0),
+        # All found correct but missing some (precision=1, recall=1/3)
+        (["A-001"], ["A-001", "A-002", "A-003"], 1.0, 1 / 3),
+        # Found more than expected (precision=0.5, recall=1)
+        (["A-001", "A-002", "A-003", "A-004"], ["A-001", "A-002"], 0.5, 1.0),
+        # Duplicates in found (set removes them)
+        (["A-001", "A-001", "A-002"], ["A-001", "A-002"], 1.0, 1.0),
+    ],
+    ids=[
+        "perfect_match",
+        "both_empty",
+        "found_empty",
+        "expected_empty",
+        "partial_overlap",
+        "no_overlap",
+        "all_correct_missing_some",
+        "found_more_than_expected",
+        "duplicates_handled",
+    ],
+)
+def test_precision_recall_calculation(
+    found: list[str],
+    expected: list[str],
+    expected_precision: float,
+    expected_recall: float,
+) -> None:
+    """Test precision and recall calculation for various scenarios."""
+    precision, recall = calculate_precision_recall(found, expected)
+    assert precision == approx(expected_precision)
+    assert recall == approx(expected_recall)
+
+
+# =============================================================================
+# Tests for Reference Extraction
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("text", "pattern", "expected_refs"),
+    [
+        # Single axiom
+        (
+            "Based on [A-001], the interest rate affects borrowing.",
+            AXIOM_PATTERN,
+            ["[A-001]"],
+        ),
+        # Multiple axioms
+        (
+            "According to [A-001] and [A-002], markets are volatile. [A-015].",
+            AXIOM_PATTERN,
+            ["[A-001]", "[A-002]", "[A-015]"],
+        ),
+        # No axioms
+        ("The economy is doing well.", AXIOM_PATTERN, []),
+        # Various number lengths
+        (
+            "[A-1] [A-12] [A-123] [A-1234]",
+            AXIOM_PATTERN,
+            ["[A-1]", "[A-12]", "[A-123]", "[A-1234]"],
+        ),
+        # Invalid patterns ignored
+        ("[B-001] [A001] A-001 [A-] [A-abc]", AXIOM_PATTERN, []),
+        # Duplicate axioms extracted separately
+        (
+            "[A-001] is important. As mentioned in [A-001], this is key.",
+            AXIOM_PATTERN,
+            ["[A-001]", "[A-001]"],
+        ),
+        # Single reality
+        (
+            "Based on [R-001], Switzerland's inflation is 2.1%.",
+            REALITY_PATTERN,
+            ["[R-001]"],
+        ),
+        # Multiple realities
+        (
+            "Given [R-001] and [R-002], the outlook is stable. See [R-007].",
+            REALITY_PATTERN,
+            ["[R-001]", "[R-002]", "[R-007]"],
+        ),
+        # No realities
+        ("The data shows positive trends.", REALITY_PATTERN, []),
+    ],
+    ids=[
+        "single_axiom",
+        "multiple_axioms",
+        "no_axioms",
+        "various_number_lengths",
+        "invalid_patterns",
+        "duplicate_axioms",
+        "single_reality",
+        "multiple_realities",
+        "no_realities",
+    ],
+)
+def test_reference_extraction(
+    text: str, pattern: str, expected_refs: list[str]
+) -> None:
+    """Test reference extraction from text using regex patterns."""
+    found = re.findall(pattern, text)
+    assert found == expected_refs
+
+
+def test_mixed_axiom_and_reality_extraction() -> None:
+    """Extract both axiom and reality references from same text."""
+    text = "Based on [A-001] and [R-001], with [A-002] and [R-002]."
+    axioms = re.findall(AXIOM_PATTERN, text)
+    realities = re.findall(REALITY_PATTERN, text)
+    assert axioms == ["[A-001]", "[A-002]"]
+    assert realities == ["[R-001]", "[R-002]"]
+
+
+# =============================================================================
+# Tests for Reference Results Models
+# =============================================================================
+
+
+def test_create_valid_axiom_results() -> None:
+    """Create a valid AxiomReferenceResults instance."""
+    result = AxiomReferenceResults(
+        references_found=["A-001", "A-002"],
+        references_expected=["A-001", "A-003"],
+        precision=0.5,
+        recall=0.5,
+    )
+    assert result.references_found == ["A-001", "A-002"]
+    assert result.references_expected == ["A-001", "A-003"]
+    assert result.precision == 0.5
+    assert result.recall == 0.5
+
+
+def test_create_valid_reality_results() -> None:
+    """Create a valid RealityReferenceResults instance."""
+    result = RealityReferenceResults(
+        references_found=["R-001"],
+        references_expected=["R-001", "R-002"],
+        precision=1.0,
+        recall=0.5,
+    )
+    assert result.references_found == ["R-001"]
+    assert result.references_expected == ["R-001", "R-002"]
+    assert result.precision == 1.0
+    assert result.recall == 0.5
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("precision", 1.5),
+        ("precision", -0.1),
+        ("recall", 1.5),
+        ("recall", -0.1),
+    ],
+    ids=[
+        "precision_above_1",
+        "precision_below_0",
+        "recall_above_1",
+        "recall_below_0",
+    ],
+)
+def test_reference_results_validation_bounds(
+    field: str, invalid_value: float
+) -> None:
+    """Precision and recall must be between 0.0 and 1.0."""
+    kwargs: dict[str, Any] = {
+        "references_found": [],
+        "references_expected": [],
+        "precision": 0.5,
+        "recall": 0.5,
+    }
+    kwargs[field] = invalid_value
+    with pytest.raises(ValueError):
+        _ = AxiomReferenceResults(**kwargs)
+
+
+def test_empty_references() -> None:
+    """Create results with empty reference lists."""
+    result = AxiomReferenceResults(
+        references_found=[],
+        references_expected=[],
+        precision=1.0,
+        recall=1.0,
+    )
+    assert result.references_found == []
+    assert result.references_expected == []
+
+
+def test_reality_inherits_from_axiom_results() -> None:
+    """RealityReferenceResults inherits from AxiomReferenceResults."""
+    result = RealityReferenceResults(
+        references_found=[],
+        references_expected=[],
+        precision=0.0,
+        recall=0.0,
+    )
+    assert isinstance(result, AxiomReferenceResults)
+
+
+# =============================================================================
+# Tests for Reference Evaluation Functions
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("found_refs", "expected_refs", "exp_precision", "exp_recall", "ref_type"),
+    [
+        # Axiom: bracket normalization
+        (["[A-001]", "[A-002]"], ["A-001", "A-002"], 1.0, 1.0, "axiom"),
+        # Axiom: partial match
+        (["[A-001]", "[A-003]"], ["A-001", "A-002"], 0.5, 0.5, "axiom"),
+        # Axiom: empty found
+        ([], ["A-001", "A-002"], 0.0, 0.0, "axiom"),
+        # Axiom: empty expected
+        (["[A-001]"], [], 0.0, 0.0, "axiom"),
+        # Axiom: both empty
+        ([], [], 1.0, 1.0, "axiom"),
+        # Reality: bracket normalization
+        (["[R-001]", "[R-002]"], ["R-001", "R-002"], 1.0, 1.0, "reality"),
+        # Reality: partial match
+        (["[R-001]", "[R-003]"], ["R-001", "R-002"], 0.5, 0.5, "reality"),
+        # Reality: both empty
+        ([], [], 1.0, 1.0, "reality"),
+    ],
+    ids=[
+        "axiom_bracket_normalization",
+        "axiom_partial_match",
+        "axiom_empty_found",
+        "axiom_empty_expected",
+        "axiom_both_empty",
+        "reality_bracket_normalization",
+        "reality_partial_match",
+        "reality_both_empty",
+    ],
+)
+def test_reference_evaluation(
+    found_refs: list[str],
+    expected_refs: list[str],
+    exp_precision: float,
+    exp_recall: float,
+    ref_type: str,
+) -> None:
+    """Test reference evaluation for both axiom and reality types."""
+    if ref_type == "axiom":
+        result = evaluate_axiom_references(found_refs, expected_refs)
+    else:
+        result = evaluate_reality_references(found_refs, expected_refs)
+
+    assert result.precision == approx(exp_precision)
+    assert result.recall == approx(exp_recall)
+
+
+def test_axiom_evaluation_removes_duplicates() -> None:
+    """Duplicate found references are deduplicated."""
+    result = evaluate_axiom_references(
+        real_axioms=["[A-001]", "[A-001]", "[A-002]"],
+        expected_axioms=["A-001", "A-002"],
+    )
+    assert len(result.references_found) == 2
+    assert result.precision == 1.0
+    assert result.recall == 1.0
+
+
+# =============================================================================
+# Tests for Metric Models
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("metric_class", "mean", "std"),
+    [
+        (AxiomPrecisionMetric, 0.85, 0.1),
+        (AxiomRecallMetric, 0.75, 0.15),
+        (RealityPrecisionMetric, 0.9, 0.05),
+        (RealityRecallMetric, 0.8, 0.12),
+    ],
+    ids=[
+        "axiom_precision",
+        "axiom_recall",
+        "reality_precision",
+        "reality_recall",
+    ],
+)
+def test_metric_model_creation(
+    metric_class: type, mean: float, std: float
+) -> None:
+    """Test creating metric models with mean and std."""
+    metric = metric_class(mean=mean, std=std)
+    assert metric.mean == mean
+    assert metric.std == std
+
+
+def test_metric_serialization() -> None:
+    """Metrics can be serialized to dict."""
+    metric = AxiomPrecisionMetric(mean=0.85, std=0.1)
+    data = metric.model_dump()
+    assert data == {"mean": 0.85, "std": 0.1}
+
+
+# =============================================================================
+# Tests for Statistics Calculation
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("scores", "expected_mean", "expected_std"),
+    [
+        # Normal case
+        ([0.8, 0.9, 0.7, 1.0], 0.85, 0.1118),
+        # Single score
+        ([0.85], 0.85, 0.0),
+        # All same scores
+        ([0.8, 0.8, 0.8, 0.8], 0.8, 0.0),
+    ],
+    ids=["normal_case", "single_score", "identical_scores"],
+)
+def test_statistics_calculation(
+    scores: list[float], expected_mean: float, expected_std: float
+) -> None:
+    """Test mean and standard deviation calculation."""
+    mean = sum(scores) / len(scores)
+    assert mean == approx(expected_mean)
+
+    if len(scores) <= 1:
+        std = 0.0
+    else:
+        variance = sum((score - mean) ** 2 for score in scores) / len(scores)
+        std = variance**0.5
+    assert std == approx(expected_std, rel=0.01)
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    (
+        "llm_answer",
+        "expected_refs",
+        "pattern",
+        "eval_func",
+        "expected_found",
+        "exp_precision",
+        "exp_recall",
+    ),
+    [
+        # Axiom evaluation workflow
+        (
+            """
+            Based on the economic principles described in [A-001] and [A-002],
+            we can see that interest rates affect borrowing. Additionally,
+            [A-003] explains how inflation impacts purchasing power.
+            """,
+            ["A-001", "A-002", "A-004"],
+            AXIOM_PATTERN,
+            evaluate_axiom_references,
+            ["[A-001]", "[A-002]", "[A-003]"],
+            2 / 3,
+            2 / 3,
+        ),
+        # Reality evaluation workflow
+        (
+            """
+            According to current data [R-001], Switzerland's inflation is 2.1%.
+            The unemployment rate [R-002] stands at 2.3%.
+            """,
+            ["R-001", "R-002", "R-003"],
+            REALITY_PATTERN,
+            evaluate_reality_references,
+            ["[R-001]", "[R-002]"],
+            1.0,
+            2 / 3,
+        ),
+    ],
+    ids=["axiom_workflow", "reality_workflow"],
+)
+def test_full_evaluation_workflow(
+    llm_answer: str,
+    expected_refs: list[str],
+    pattern: str,
+    eval_func: Any,
+    expected_found: list[str],
+    exp_precision: float,
+    exp_recall: float,
+) -> None:
+    """Test complete evaluation workflow from LLM text to results."""
+    # Extract references from LLM answer
+    found_raw = re.findall(pattern, llm_answer)
+    assert found_raw == expected_found
+
+    # Evaluate
+    result = eval_func(found_raw, expected_refs)
+    assert result.precision == approx(exp_precision)
+    assert result.recall == approx(exp_recall)
+
+
+def test_mixed_references_in_answer() -> None:
+    """Test extracting both axiom and reality references from same text."""
+    llm_answer = """
+    Based on [A-001] and current data [R-001], we see that [A-002]
+    applies here. The reality [R-002] confirms this analysis.
+    """
+    axioms_found = re.findall(AXIOM_PATTERN, llm_answer)
+    realities_found = re.findall(REALITY_PATTERN, llm_answer)
+    assert axioms_found == ["[A-001]", "[A-002]"]
+    assert realities_found == ["[R-001]", "[R-002]"]
+
+    # Evaluate separately
+    axiom_result = evaluate_axiom_references(axioms_found, ["A-001", "A-002"])
+    reality_result = evaluate_reality_references(
+        realities_found, ["R-001", "R-002"]
+    )
+    assert axiom_result.precision == 1.0
+    assert axiom_result.recall == 1.0
+    assert reality_result.precision == 1.0
+    assert reality_result.recall == 1.0

--- a/tests/eval/test_reference_evaluation.py
+++ b/tests/eval/test_reference_evaluation.py
@@ -13,6 +13,7 @@ import re
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from pytest import approx  # type: ignore[reportUnknownMemberType]
 
 from eval.eval import (
@@ -246,7 +247,7 @@ def test_reference_results_validation_bounds(
         "recall": 0.5,
     }
     kwargs[field] = invalid_value
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         _ = AxiomReferenceResults(**kwargs)
 
 
@@ -263,7 +264,8 @@ def test_empty_references() -> None:
 
 
 def test_reference_results_inheritance() -> None:
-    """Both AxiomReferenceResults and RealityReferenceResults inherit from ReferenceResults."""
+    """Both AxiomReferenceResults and RealityReferenceResults 
+    inherit from ReferenceResults."""
     axiom_result = AxiomReferenceResults(
         references_found=[],
         references_expected=[],

--- a/tests/eval/test_reference_evaluation.py
+++ b/tests/eval/test_reference_evaluation.py
@@ -36,6 +36,7 @@ from eval.models import (
     RealityRecallMetric,
     RealityReferenceResults,
     RealityReferences,
+    ReferenceResults,
 )
 
 # =============================================================================
@@ -261,15 +262,25 @@ def test_empty_references() -> None:
     assert result.references_expected == []
 
 
-def test_reality_inherits_from_axiom_results() -> None:
-    """RealityReferenceResults inherits from AxiomReferenceResults."""
-    result = RealityReferenceResults(
+def test_reference_results_inheritance() -> None:
+    """Both AxiomReferenceResults and RealityReferenceResults inherit from ReferenceResults."""
+    axiom_result = AxiomReferenceResults(
         references_found=[],
         references_expected=[],
         precision=0.0,
         recall=0.0,
     )
-    assert isinstance(result, AxiomReferenceResults)
+    reality_result = RealityReferenceResults(
+        references_found=[],
+        references_expected=[],
+        precision=0.0,
+        recall=0.0,
+    )
+    assert isinstance(axiom_result, ReferenceResults)
+    assert isinstance(reality_result, ReferenceResults)
+    # Ensure they are not related to each other
+    assert not isinstance(axiom_result, RealityReferenceResults)
+    assert not isinstance(reality_result, AxiomReferenceResults)
 
 
 # =============================================================================

--- a/tests/eval/test_reference_evaluation.py
+++ b/tests/eval/test_reference_evaluation.py
@@ -264,7 +264,7 @@ def test_empty_references() -> None:
 
 
 def test_reference_results_inheritance() -> None:
-    """Both AxiomReferenceResults and RealityReferenceResults 
+    """Both AxiomReferenceResults and RealityReferenceResults
     inherit from ReferenceResults."""
     axiom_result = AxiomReferenceResults(
         references_found=[],

--- a/tests/eval/test_report_generation.py
+++ b/tests/eval/test_report_generation.py
@@ -28,7 +28,8 @@ def sample_evaluation_data() -> dict[str, Any]:
                         "account is $10,000"
                     ),
                     "reasoning": ["Premium account requirements"],
-                    "axioms_used": ["AXIOM-001"],
+                    "axioms_used": ["A-001"],
+                    "reality_used": ["R-001"],
                 },
                 "llm_response": (
                     "The minimum balance required for a premium savings "
@@ -75,6 +76,18 @@ def sample_evaluation_data() -> dict[str, Any]:
                     "reason": "Good coverage of expected topics",
                     "coverage_score": 0.9,
                 },
+                "axiom_references": {
+                    "references_found": ["A-001"],
+                    "references_expected": ["A-001"],
+                    "precision": 1.0,
+                    "recall": 1.0,
+                },
+                "reality_references": {
+                    "references_found": ["R-001"],
+                    "references_expected": ["R-001"],
+                    "precision": 1.0,
+                    "recall": 1.0,
+                },
             },
             {
                 "input": {
@@ -90,6 +103,7 @@ def sample_evaluation_data() -> dict[str, Any]:
                     ),
                     "reasoning": ["Standard fixed deposit rates"],
                     "axioms_used": [],
+                    "reality_used": [],
                 },
                 "llm_response": (
                     "The interest rate for a 12-month fixed deposit is "
@@ -132,6 +146,18 @@ def sample_evaluation_data() -> dict[str, Any]:
                     "reason": "Full coverage of expected content",
                     "coverage_score": 1.0,
                 },
+                "axiom_references": {
+                    "references_found": [],
+                    "references_expected": [],
+                    "precision": 1.0,
+                    "recall": 1.0,
+                },
+                "reality_references": {
+                    "references_found": [],
+                    "references_expected": [],
+                    "precision": 1.0,
+                    "recall": 1.0,
+                },
             },
         ],
         "accuracy": {
@@ -141,6 +167,22 @@ def sample_evaluation_data() -> dict[str, Any]:
         "topic_coverage": {
             "mean": 0.95,
             "std": 0.05,
+        },
+        "axiom_precision_metric": {
+            "mean": 1.0,
+            "std": 0.0,
+        },
+        "axiom_recall_metric": {
+            "mean": 1.0,
+            "std": 0.0,
+        },
+        "reality_precision_metric": {
+            "mean": 1.0,
+            "std": 0.0,
+        },
+        "reality_recall_metric": {
+            "mean": 1.0,
+            "std": 0.0,
         },
     }
 
@@ -232,6 +274,10 @@ def test_load_json_data_complete_structure_no_error(
         "evaluation_outputs": [],
         "accuracy": {"mean": 0.0, "std": 0.0},
         "topic_coverage": {"mean": 0.0, "std": 0.0},
+        "axiom_precision_metric": {"mean": 0.0, "std": 0.0},
+        "axiom_recall_metric": {"mean": 0.0, "std": 0.0},
+        "reality_precision_metric": {"mean": 0.0, "std": 0.0},
+        "reality_recall_metric": {"mean": 0.0, "std": 0.0},
     }
     with open(complete_json_file, "w", encoding="utf-8") as f:
         json.dump(complete_data, f)


### PR DESCRIPTION
This pull request adds support for evaluating axiom and reality reference precision and recall in the LLM evaluation pipeline. It introduces new metrics for both axiom and reality references, updates the evaluation process to compute and store these metrics, and extends the report template to display them. Additionally, the evaluation dataset and models are updated to include expected reality references.
