### PR TITLE
Add inline reference highlighting with tooltips for axioms and realities

### DIFF
--- a/bin/lint/md
+++ b/bin/lint/md
@@ -24,7 +24,7 @@ while :; do
 done
 
 if [[ $fix ]]; then
-    npx markdownlint --fix '**/*.md' --ignore node_modules --ignore .venv --ignore runs --ignore .github/**/*.md
+    npx markdownlint --fix '**/*.md' --ignore node_modules --ignore .venv --ignore runs --ignore '.github/**'
 else
-    npx markdownlint '**/*.md' --ignore node_modules --ignore .venv --ignore runs --ignore .github/**/*.md
+    npx markdownlint '**/*.md' --ignore node_modules --ignore .venv --ignore runs --ignore '.github/**'
 fi

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -235,7 +235,8 @@ function highlightReferencesInText(text, axiomDefinitionsMap, realityDefinitions
 
     // Match patterns like [A-001], [A-002], [R-001], [R-002], etc.
     // The pattern captures the full reference including brackets
-    const referencePattern = /\[(A-\d+|R-\d+)\]/g;
+    // Limit the numeric part to 1–4 digits to avoid matching excessively long IDs
+    const referencePattern = /\[(A-\d{1,4}|R-\d{1,4})\]/g;
 
     return text.replace(referencePattern, (match, refId) => {
         const isAxiom = refId.startsWith('A-');

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -258,9 +258,11 @@ function highlightReferencesInText(text, axiomDefinitionsMap, realityDefinitions
  * Entities are sorted by length (longest first) to avoid partial matches.
  * Each entity gets a consistent color based on its assigned color index.
  * 
- * IMPORTANT: Entity highlighting is applied FIRST on plain text, then reference
- * highlighting is applied. This order prevents entity matching inside tooltip
- * attribute values, which would break HTML structure.
+ * IMPORTANT: Entity highlighting is applied FIRST on the raw text (including
+ * any reference markers like [A-001]), and reference highlighting is applied
+ * SECOND. Because of this order, entity patterns can match inside reference
+ * markers before they are wrapped in tooltip spans, so entity patterns should
+ * be chosen carefully to avoid interfering with reference matching.
  * 
  * @param {string} text - The text to highlight entities in
  * @param {Array<string>} entities - Array of entity strings to highlight

--- a/src/eval/report_generation/templates/script.js
+++ b/src/eval/report_generation/templates/script.js
@@ -230,7 +230,7 @@ function findEntitiesInText(text, entities) {
  */
 function highlightReferencesInText(text, axiomDefinitionsMap, realityDefinitionsMap) {
     if (!text) {
-        return text;
+        return '';
     }
 
     // Match patterns like [A-001], [A-002], [R-001], [R-002], etc.

--- a/src/eval/report_generation/templates/styles.css
+++ b/src/eval/report_generation/templates/styles.css
@@ -422,6 +422,97 @@ body {
     box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.5);
 }
 
+/* ============================================================================
+   Inline Reference Tooltips (for references found in text like [A-001], [R-001])
+   ============================================================================ */
+
+.inline-reference {
+    position: relative;
+    display: inline;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 0.9em;
+    cursor: help;
+}
+
+.inline-axiom-ref {
+    background: #fff3e0;
+    color: #e65100;
+    border: 1px solid #ffcc80;
+}
+
+.inline-reality-ref {
+    background: #e8f5e9;
+    color: #2e7d32;
+    border: 1px solid #a5d6a7;
+}
+
+/* Tooltip for inline references */
+.inline-reference[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #333;
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-weight: 400;
+    white-space: normal;
+    max-width: 300px;
+    min-width: 150px;
+    width: max-content;
+    text-align: left;
+    line-height: 1.4;
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    pointer-events: none;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* Tooltip arrow for inline references */
+.inline-reference[data-tooltip]::before {
+    content: '';
+    position: absolute;
+    bottom: calc(100% + 2px);
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #333;
+    z-index: 1001;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    pointer-events: none;
+}
+
+/* Show tooltip on hover for inline references */
+.inline-reference[data-tooltip]:hover::after,
+.inline-reference[data-tooltip]:hover::before {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* Show tooltip on focus for accessibility */
+.inline-reference[data-tooltip]:focus::after,
+.inline-reference[data-tooltip]:focus::before {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* Allow focus on inline references with tooltips */
+.inline-reference[data-tooltip]:focus {
+    outline: 2px solid #0056b3;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.5);
+}
+
 .expected-tag {
     background: #e3f2fd;
     color: #1565c0;

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -569,7 +569,6 @@ describe("renderReferences", () => {
  */
 function highlightReferencesInText(
   text: string | null | undefined,
-  text: string,
   axiomDefinitionsMap: Map<string, string>,
   realityDefinitionsMap: Map<string, string>
 ): string {

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -174,7 +174,7 @@ describe("renderAxiomDefinitions", () => {
 
   it("should log error when container element is missing", () => {
     document.body.innerHTML = ""; // Remove the container
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => { });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     renderAxiomDefinitions();
 
@@ -240,7 +240,7 @@ describe("renderRealityDefinitions", () => {
 
   it("should log error when container element is missing", () => {
     document.body.innerHTML = ""; // Remove the container
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => { });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     renderRealityDefinitions();
 
@@ -333,29 +333,31 @@ function renderReferences(
                 <div class="references-card">
                     <h5>Expected</h5>
                     <div class="reference-list">
-                        ${references.references_expected.length > 0
-      ? references.references_expected
-        .map((ref) => renderReferenceTag(ref, "expected-tag", defMap))
-        .join("")
-      : '<p style="color: #666; font-style: italic;">None expected</p>'
-    }
+                        ${
+                          references.references_expected.length > 0
+                            ? references.references_expected
+                                .map((ref) => renderReferenceTag(ref, "expected-tag", defMap))
+                                .join("")
+                            : '<p style="color: #666; font-style: italic;">None expected</p>'
+                        }
                     </div>
                 </div>
                 <div class="references-card">
                     <h5>Found in Response</h5>
                     <div class="reference-list">
-                        ${references.references_found.length > 0
-      ? references.references_found
-        .map((ref) => {
-          const isMatch = references.references_expected.includes(ref);
-          const tagClass = isMatch
-            ? "found-match-tag"
-            : "found-nomatch-tag";
-          return renderReferenceTag(ref, tagClass, defMap);
-        })
-        .join("")
-      : '<p style="color: #666; font-style: italic;">None found</p>'
-    }
+                        ${
+                          references.references_found.length > 0
+                            ? references.references_found
+                                .map((ref) => {
+                                  const isMatch = references.references_expected.includes(ref);
+                                  const tagClass = isMatch
+                                    ? "found-match-tag"
+                                    : "found-nomatch-tag";
+                                  return renderReferenceTag(ref, tagClass, defMap);
+                                })
+                                .join("")
+                            : '<p style="color: #666; font-style: italic;">None found</p>'
+                        }
                     </div>
                 </div>
             </div>

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -174,7 +174,7 @@ describe("renderAxiomDefinitions", () => {
 
   it("should log error when container element is missing", () => {
     document.body.innerHTML = ""; // Remove the container
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => { });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     renderAxiomDefinitions();
 
@@ -240,7 +240,7 @@ describe("renderRealityDefinitions", () => {
 
   it("should log error when container element is missing", () => {
     document.body.innerHTML = ""; // Remove the container
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => { });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     renderRealityDefinitions();
 
@@ -333,29 +333,31 @@ function renderReferences(
                 <div class="references-card">
                     <h5>Expected</h5>
                     <div class="reference-list">
-                        ${references.references_expected.length > 0
-      ? references.references_expected
-        .map((ref) => renderReferenceTag(ref, "expected-tag", defMap))
-        .join("")
-      : '<p style="color: #666; font-style: italic;">None expected</p>'
-    }
+                        ${
+                          references.references_expected.length > 0
+                            ? references.references_expected
+                                .map((ref) => renderReferenceTag(ref, "expected-tag", defMap))
+                                .join("")
+                            : '<p style="color: #666; font-style: italic;">None expected</p>'
+                        }
                     </div>
                 </div>
                 <div class="references-card">
                     <h5>Found in Response</h5>
                     <div class="reference-list">
-                        ${references.references_found.length > 0
-      ? references.references_found
-        .map((ref) => {
-          const isMatch = references.references_expected.includes(ref);
-          const tagClass = isMatch
-            ? "found-match-tag"
-            : "found-nomatch-tag";
-          return renderReferenceTag(ref, tagClass, defMap);
-        })
-        .join("")
-      : '<p style="color: #666; font-style: italic;">None found</p>'
-    }
+                        ${
+                          references.references_found.length > 0
+                            ? references.references_found
+                                .map((ref) => {
+                                  const isMatch = references.references_expected.includes(ref);
+                                  const tagClass = isMatch
+                                    ? "found-match-tag"
+                                    : "found-nomatch-tag";
+                                  return renderReferenceTag(ref, tagClass, defMap);
+                                })
+                                .join("")
+                            : '<p style="color: #666; font-style: italic;">None found</p>'
+                        }
                     </div>
                 </div>
             </div>
@@ -622,7 +624,7 @@ describe("highlightReferencesInText", () => {
     expect(result).toContain('class="inline-reference inline-axiom-ref"');
     expect(result).toContain('data-tooltip="First axiom description"');
     expect(result).toContain("[A-001]");
-    expect(result).toContain("tabindex=\"0\"");
+    expect(result).toContain('tabindex="0"');
   });
 
   it("should highlight reality references with tooltips", () => {

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -577,7 +577,7 @@ function highlightReferencesInText(
   }
 
   // Match patterns like [A-001], [A-002], [R-001], [R-002], etc.
-  const referencePattern = /\[(A-\d+|R-\d+)\]/g;
+  const referencePattern = /\[(A-\d{1,4}|R-\d{1,4})\]/g;
 
   return text.replace(referencePattern, (match, refId: string) => {
     const isAxiom = refId.startsWith("A-");

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -569,14 +569,10 @@ describe("renderReferences", () => {
  */
 function highlightReferencesInText(
   text: string | null | undefined,
+  text: string,
   axiomDefinitionsMap: Map<string, string>,
   realityDefinitionsMap: Map<string, string>
 ): string {
-  if (text == null) {
-    // Normalize null/undefined to empty string to avoid "null"/"undefined" in HTML
-    return "";
-  }
-
   // Match patterns like [A-001], [A-002], [R-001], [R-002], etc.
   const referencePattern = /\[(A-\d+|R-\d+)\]/g;
 

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -572,6 +572,10 @@ function highlightReferencesInText(
   axiomDefinitionsMap: Map<string, string>,
   realityDefinitionsMap: Map<string, string>
 ): string {
+  if (!text) {
+    return text ?? "";
+  }
+
   // Match patterns like [A-001], [A-002], [R-001], [R-002], etc.
   const referencePattern = /\[(A-\d+|R-\d+)\]/g;
 

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -573,7 +573,7 @@ function highlightReferencesInText(
   realityDefinitionsMap: Map<string, string>
 ): string {
   if (!text) {
-    return text ?? "";
+    return "";
   }
 
   // Match patterns like [A-001], [A-002], [R-001], [R-002], etc.

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -572,8 +572,9 @@ function highlightReferencesInText(
   axiomDefinitionsMap: Map<string, string>,
   realityDefinitionsMap: Map<string, string>
 ): string {
-  if (!text) {
-    return text ?? "";
+  if (text == null) {
+    // Normalize null/undefined to empty string to avoid "null"/"undefined" in HTML
+    return "";
   }
 
   // Match patterns like [A-001], [A-002], [R-001], [R-002], etc.

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -595,16 +595,16 @@ function highlightReferencesInText(
 }
 
 describe("highlightReferencesInText", () => {
-  it("should return empty string for null text", () => {
+  it("should return null for null text", () => {
     const axiomMap = new Map<string, string>();
     const realityMap = new Map<string, string>();
-    expect(highlightReferencesInText(null, axiomMap, realityMap)).toBe("");
+    expect(highlightReferencesInText(null, axiomMap, realityMap)).toBe(null);
   });
 
-  it("should return empty string for undefined text", () => {
+  it("should return undefined for undefined text", () => {
     const axiomMap = new Map<string, string>();
     const realityMap = new Map<string, string>();
-    expect(highlightReferencesInText(undefined, axiomMap, realityMap)).toBe("");
+    expect(highlightReferencesInText(undefined, axiomMap, realityMap)).toBeUndefined();
   });
 
   it("should return text unchanged when no references found", () => {

--- a/tests/ui/report-script.spec.ts
+++ b/tests/ui/report-script.spec.ts
@@ -777,8 +777,8 @@ function getEntityColor(entity: string): number {
  * Converts line break characters to HTML <br> tags.
  * This is a simplified copy of the function from script.js for testing.
  */
-function convertLineBreaks(text: string | null | undefined): string {
-  if (!text) return text ?? "";
+function convertLineBreaks(text: string | null | undefined): string | null | undefined {
+  if (!text) return text;
   return text
     .replace(/\r\n/g, "<br>")
     .replace(/\n/g, "<br>")
@@ -796,10 +796,10 @@ function highlightEntitiesInText(
   entities: string[] | null | undefined,
   axiomDefinitionsMap?: Map<string, string>,
   realityDefinitionsMap?: Map<string, string>
-): string {
+): string | null | undefined {
   if (!text || !entities || entities.length === 0) {
     // Still apply reference highlighting even if no entities
-    let result = text ?? "";
+    let result = text;
     if (axiomDefinitionsMap && realityDefinitionsMap) {
       result = highlightReferencesInText(result, axiomDefinitionsMap, realityDefinitionsMap);
     }
@@ -848,14 +848,14 @@ describe("highlightEntitiesInText", () => {
     expect(result).toBe("Hello<br>World");
   });
 
-  it("should return empty string for null text", () => {
+  it("should return null for null text", () => {
     const result = highlightEntitiesInText(null, ["entity"]);
-    expect(result).toBe("");
+    expect(result).toBeNull();
   });
 
-  it("should return empty string for undefined text", () => {
+  it("should return undefined for undefined text", () => {
     const result = highlightEntitiesInText(undefined, ["entity"]);
-    expect(result).toBe("");
+    expect(result).toBeUndefined();
   });
 
   it("should highlight a single entity", () => {
@@ -885,7 +885,7 @@ describe("highlightEntitiesInText", () => {
     const result = highlightEntitiesInText(text, entities);
 
     // Both occurrences should be highlighted
-    const highlightCount = (result.match(/entity-highlight/g) || []).length;
+    const highlightCount = (result!.match(/entity-highlight/g) || []).length;
     expect(highlightCount).toBe(2);
   });
 
@@ -896,7 +896,7 @@ describe("highlightEntitiesInText", () => {
     const result = highlightEntitiesInText(text, entities);
 
     // Should only match "market" not "markets"
-    const highlightCount = (result.match(/entity-highlight/g) || []).length;
+    const highlightCount = (result!.match(/entity-highlight/g) || []).length;
     expect(highlightCount).toBe(1);
   });
 
@@ -911,7 +911,7 @@ describe("highlightEntitiesInText", () => {
     expect(result).toContain("entity-highlight");
     expect(result).toContain("interest rate</span>");
     // The sorting ensures longer matches are attempted first to minimize nesting issues
-    const highlightCount = (result.match(/entity-highlight/g) || []).length;
+    const highlightCount = (result!.match(/entity-highlight/g) || []).length;
     expect(highlightCount).toBeGreaterThanOrEqual(2);
   });
 });
@@ -988,7 +988,7 @@ describe("highlightEntitiesInText with References - Integration Tests", () => {
     const result = highlightEntitiesInText(text, entities, axiomMap, realityMap);
 
     // Both occurrences of A-001 (inside and outside brackets) are highlighted as entities
-    const entityHighlightCount = (result.match(/entity-highlight/g) || []).length;
+    const entityHighlightCount = (result!.match(/entity-highlight/g) || []).length;
     expect(entityHighlightCount).toBe(2);
 
     // Note: The reference tooltip will NOT be applied because entity highlighting


### PR DESCRIPTION
This pull request introduces inline highlighting and tooltip support for axiom and reality references (such as `[A-001]` or `[R-001]`) within evaluation report texts. It also adds comprehensive styling and test coverage for this new feature. The main changes are grouped into three themes: feature implementation, UI/UX enhancements, and testing.

**Feature Implementation:**

* Added the `highlightReferencesInText` function to `script.js`, which detects axiom and reality references in text and wraps them in `<span>` elements with tooltips showing their definitions. This function is integrated into the entity highlighting pipeline, ensuring references are highlighted after entities to avoid breaking HTML structure. (`src/eval/report_generation/templates/script.js` [[1]](diffhunk://#diff-bb42210cb427086752f553261afcfd98fedc1b9ed27021a1d7b8fb2971d1b74fR223-R283) [[2]](diffhunk://#diff-bb42210cb427086752f553261afcfd98fedc1b9ed27021a1d7b8fb2971d1b74fR300-R305)
* Updated the `highlightEntitiesInText` and `renderEvaluation` functions to support and utilize the new reference highlighting, ensuring references are highlighted in both expected and actual response outputs. (`src/eval/report_generation/templates/script.js` [[1]](diffhunk://#diff-bb42210cb427086752f553261afcfd98fedc1b9ed27021a1d7b8fb2971d1b74fR223-R283) [[2]](diffhunk://#diff-bb42210cb427086752f553261afcfd98fedc1b9ed27021a1d7b8fb2971d1b74fL508-R571)

**UI/UX Enhancements:**

* Added new CSS styles for `.inline-reference`, `.inline-axiom-ref`, and `.inline-reality-ref` classes, including visually distinctive backgrounds, borders, and accessible tooltips that appear on hover and focus. This improves the clarity and accessibility of references in the report. (`src/eval/report_generation/templates/styles.css` [src/eval/report_generation/templates/styles.cssR425-R515](diffhunk://#diff-911834d89a81cba5ad3f78aeb058b057a2e9e6f8e226ca7111b9e32e7adf3463R425-R515))

**Testing:**

* Added a comprehensive suite of tests for the reference highlighting logic, covering cases such as missing definitions, HTML escaping, multiple references, and accessibility. This ensures robust and secure handling of references in all scenarios. (`tests/ui/report-script.spec.ts` [tests/ui/report-script.spec.tsR560-R720](diffhunk://#diff-5b1e5f46e49d565ca72eae8aa637a69298104f092d4334bbd8d5813e22d13604R560-R720))
* Minor adjustments to test rendering logic for references to support the new inline highlighting feature. (`tests/ui/report-script.spec.ts` [[1]](diffhunk://#diff-5b1e5f46e49d565ca72eae8aa637a69298104f092d4334bbd8d5813e22d13604L336-R336) [[2]](diffhunk://#diff-5b1e5f46e49d565ca72eae8aa637a69298104f092d4334bbd8d5813e22d13604L348-R347)